### PR TITLE
MediaStreamTrackProcessorを使うように例示しているコードを変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # webcodecs-stuck-point-example
 
 ## 注意点
-GoogleChromeに`--enable-blink-features=WebCodecs`オプションをつけて起動する必要がある
+GoogleChromeに`--enable-blink-features=WebCodecs,MediaStreamInsertableStreams`オプションをつけて起動する必要がある。
 
-例えばmacだと`open -a /Applications/Google\ Chrome\ Beta.app  --args --use-fake-device-for-media-stream --enable-blink-features=WebCodecs`のようになる
+例えばmacだと`open -a /Applications/Google\ Chrome\ Beta.app  --args --use-fake-device-for-media-stream --enable-blink-features=WebCodecs,MediaStreamInsertableStreams`のようになる。
+
+また、入力のカメラはVideoEncoderのconfigureの設定に合うものを使うか、設定の方をカメラに合わせる必要がある。
+サンプルのコードでは`--use-fake-device-for-media-strea`フラグを付けて起動した時の偽の映像やFaceTime HDカメラなどが対応している解像度になっている。

--- a/color/script.js
+++ b/color/script.js
@@ -1,5 +1,3 @@
-let requestKeyFrame = true;
-
 const createEncoderAndDecoder = async (stream, videoElement, codec='vp8') => {
     const chunkQueue = [];
 
@@ -35,18 +33,30 @@ const createEncoderAndDecoder = async (stream, videoElement, codec='vp8') => {
         height: 480,
         framerate: 30,
     });
-    
-    const videoReader = new VideoTrackReader(videoTrack);
-    let cnt = 0; // keyframeを送るかどうかの判定に利用
-    const keyframeRate = 600; // keyframeを送る間隔
-    videoReader.start(videoFrame => {
-        cnt = (cnt + 1) % keyframeRate;
 
-        videoEncoder.encode(videoFrame, {
-            keyFrame: !cnt || requestKeyFrame,
-        });
-        requestKeyFrame = false;
-    });
+    let cnt = 0; // keyframeを送るかどうかの判定に利用
+    const keyframeRate = 600; // keyframeを送る間隔 => 20s
+
+    const processor = new MediaStreamTrackProcessor(videoTrack);
+    const frameReader = processor.readable.getReader();
+    setTimeout(async () => {
+        while (true) {
+            const { done, value: videoFrame } = await frameReader.read();
+        
+            if (done) {
+              console.log('Stream is done');
+              break;
+            }
+        
+            cnt = (cnt + 1) % keyframeRate;
+
+            // 定期的またはkeyframe要求によってkeyframeを送る
+            const isKeyFrame = !cnt;
+            videoEncoder.encode(videoFrame, {
+                keyFrame: isKeyFrame,
+            });
+          }
+    }, 0);
 
     /**
      * Decoder

--- a/loss/02/script.js
+++ b/loss/02/script.js
@@ -43,23 +43,34 @@ const createEncoderAndDecoder = async (stream, videoElement, codec = 'vp8') => {
         framerate: 30,
     });
 
-    const videoReader = new VideoTrackReader(videoTrack);
     let cnt = 0; // keyframeを送るかどうかの判定に利用
     let lastKeyFrameCount = 0;
     const keyframeRate = 150; // keyframeを送る間隔 => 5s
-    videoReader.start(videoFrame => {
-        cnt = (cnt + 1) % keyframeRate;
 
-        // 定期的または前回のkeyframeから一定時間後のkeyframe要求によってkeyframeを送る
-        const isKeyFrame = !cnt || (requestKeyFrame && (cnt - lastKeyFrameCount + keyframeRate) % keyframeRate > 30);
-        videoEncoder.encode(videoFrame, {
-            keyFrame: isKeyFrame,
-        });
-        requestKeyFrame = false;
-        if (isKeyFrame) {
-            lastKeyFrameCount = cnt;
-        }
-    });
+    const processor = new MediaStreamTrackProcessor(videoTrack);
+    const frameReader = processor.readable.getReader();
+    setTimeout(async () => {
+        while (true) {
+            const { done, value: videoFrame } = await frameReader.read();
+        
+            if (done) {
+              console.log('Stream is done');
+              break;
+            }
+        
+            cnt = (cnt + 1) % keyframeRate;
+
+            // 定期的または前回のkeyframeから一定時間後のkeyframe要求によってkeyframeを送る
+            const isKeyFrame = !cnt || (requestKeyFrame && (cnt - lastKeyFrameCount + keyframeRate) % keyframeRate > 30);
+            videoEncoder.encode(videoFrame, {
+                keyFrame: isKeyFrame,
+            });
+            requestKeyFrame = false;
+            if (isKeyFrame) {
+                lastKeyFrameCount = cnt;
+            }
+          }
+    }, 0);
 
     /**
      * Decoder


### PR DESCRIPTION
`VideoTrackReader`が将来deprecatedになるので、VideoFrame取得部分を`MediaStreamTrackProcessor`を利用したコードに変更した